### PR TITLE
Fix aspect ratio issues in preview

### DIFF
--- a/Application/src/main/java/com/example/android/camera2basic/AutoFitTextureView.java
+++ b/Application/src/main/java/com/example/android/camera2basic/AutoFitTextureView.java
@@ -65,7 +65,7 @@ public class AutoFitTextureView extends TextureView {
         if (0 == mRatioWidth || 0 == mRatioHeight) {
             setMeasuredDimension(width, height);
         } else {
-            if (width < height * mRatioWidth / mRatioHeight) {
+            if (width > height * mRatioWidth / mRatioHeight) {
                 setMeasuredDimension(width, width * mRatioHeight / mRatioWidth);
             } else {
                 setMeasuredDimension(height * mRatioWidth / mRatioHeight, height);


### PR DESCRIPTION
This minor change fixes the display of black bars on multiple devices, caused by a wrongly set aspect ratio. This should fix the problems mentioned in issues #69 #66 and possibly #38 and #9 .