### PR TITLE
Unexpected exception at Huawei and some other devices

### DIFF
--- a/Application/src/main/java/com/example/android/camera2basic/Camera2BasicFragment.java
+++ b/Application/src/main/java/com/example/android/camera2basic/Camera2BasicFragment.java
@@ -842,7 +842,6 @@ public class Camera2BasicFragment extends Fragment
             };
 
             mCaptureSession.stopRepeating();
-            mCaptureSession.abortCaptures();
             mCaptureSession.capture(captureBuilder.build(), CaptureCallback, null);
         } catch (CameraAccessException e) {
             e.printStackTrace();


### PR DESCRIPTION
**About the problem:**
There is CameraAccessException occuring on some devices (like _Huawei P10_, _Huawei Honor 6A_, _Samsung Galaxy A3_, etc) during capturing.

**Exception description (can differ at different devices):**
```
 android.hardware.camera2.CameraAccessException: CAMERA_ERROR (3): submitRequestList:267: Camera 0: Got error Invalid argument (-22) after trying to submit capture request
                             at android.hardware.camera2.CameraManager.throwAsPublicException(CameraManager.java:633)
                             at android.hardware.camera2.impl.ICameraDeviceUserWrapper.submitRequestList(ICameraDeviceUserWrapper.java:86)
                             at android.hardware.camera2.impl.CameraDeviceImpl.submitCaptureRequest(CameraDeviceImpl.java:865)
                             at android.hardware.camera2.impl.CameraDeviceImpl.capture(CameraDeviceImpl.java:754)
                             at android.hardware.camera2.impl.CameraCaptureSessionImpl.capture(CameraCaptureSessionImpl.java:179)
```

**Understanding the problem:**
According to the AOSP documentation to[ abortCaptures method](https://android.googlesource.com/platform/frameworks/base/+/5398a67/core/java/android/hardware/camera2/CameraCaptureSession.java#375), the use of the method during capture is unjustified.

><p>This means that using {@code abortCaptures()} to simply remove pending requests is not
>recommended; it's best used for quickly switching output configurations, or for cancelling
> long in-progress requests (such as a multi-second capture).</p>

Probably, the session of the camera _on some devices_ will be close (_it is also an undocumented feature_) with the call of this method, however, the fact `abortCaptures` method is left abstract at [CameraCaptureSession](https://android.googlesource.com/platform/frameworks/base/+/5398a67/core/java/android/hardware/camera2/CameraCaptureSession.java) means its implementation lies on the device and firmware manufacturers.

The production is cruel, and we have to put up with its realities. :crying_cat_face: 

**Solution:**
Remove an unnecessary method call.
