### PR TITLE
Capture function doesn't work on Some devices

### DIFF
--- a/Application/src/main/java/com/example/android/camera2basic/Camera2BasicFragment.java
+++ b/Application/src/main/java/com/example/android/camera2basic/Camera2BasicFragment.java
@@ -294,7 +294,7 @@ public class Camera2BasicFragment extends Fragment
                 }
                 case STATE_WAITING_LOCK: {
                     Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
-                    if (afState == null) {
+                    if (afState == null||afState == 0) {
                         captureStillPicture();
                     } else if (CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED == afState ||
                             CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED == afState) {


### PR DESCRIPTION
I used this code on my phone（Redmi 4x）and saw nothing happened after pressing the "Picture" button, by tracing the state of "afState" , I found that the case “STATE_WAITING_LOCK” did nothing when “afState==0”,which is the exact returned value of Redmi 4x.